### PR TITLE
fix issue with ui elements not fitting within given viewport 

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -18,3 +18,7 @@ config/icon="res://icon.svg"
 [debug]
 
 shapes/paths/geometry_width=100.0
+
+[display]
+
+window/stretch/mode="canvas_items"


### PR DESCRIPTION
set display window/stretch/mode to canvas items in project settings

closes #2 